### PR TITLE
Fix Django 1.6 compat with correct urls imports.

### DIFF
--- a/mockdjangosaml2/urls.py
+++ b/mockdjangosaml2/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import patterns, url
+from django.conf.urls import patterns, url
 
 urlpatterns = patterns(
     'mockdjangosaml2.views',

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_packages(),
     include_package_data=True,
     install_requires=[
-        'Django>=1.2',
+        'Django>=1.4',
     ],
     long_description = read('README.rst'),
 )


### PR DESCRIPTION
Django 1.6 [removed](http://stackoverflow.com/a/19962822/1489738) `django.conf.urls.defaults` - this pull fixes the urls.py imports.

Unfortunately this breaks Django <1.4.
