### PR TITLE
Add django 1.7 compatibility

### DIFF
--- a/mockdjangosaml2/views.py
+++ b/mockdjangosaml2/views.py
@@ -33,7 +33,6 @@ class MockAuthForm(AuthenticationForm):
                     self.error_messages['invalid_login'] % {
                         'username': self.username_field.verbose_name
                     })
-        self.check_for_test_cookie()
         return self.cleaned_data
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
     
 setup(
     name='mockdjangosaml2',
-    version='0.10.1',
+    version='0.10.2',
     url='http://github.com/darbula/mockdjangosaml2',
     author='Damir Arbula',
     author_email='damir.arbula@gmail.com',


### PR DESCRIPTION
This PR removes a call to the undocumented `check_for_test_cookie` method on the `AuthenticationForm` class. This method was removed in Django 1.7 following an accelerated deprecation.

http://django.readthedocs.org/en/latest/internals/deprecation.html#deprecation-removed-in-1-7 