### PR TITLE
Add request argument to authenticate

### DIFF
--- a/mockdjangosaml2/views.py
+++ b/mockdjangosaml2/views.py
@@ -106,7 +106,8 @@ def assertion_consumer_service(request,
     session_info = request.session['mock_session_info']
     came_from = request.session['mock_came_from']
     logger.debug('Trying to authenticate the user')
-    user = auth.authenticate(session_info=session_info,
+    user = auth.authenticate(request=request,
+                             session_info=session_info,
                              attribute_mapping=attribute_mapping,
                              create_unknown_user=create_unknown_user)
     if user is None:


### PR DESCRIPTION
djangosaml2 now requires request argument in authenticate method.